### PR TITLE
Fix #3: check token password before signature.

### DIFF
--- a/data/certChooser.html
+++ b/data/certChooser.html
@@ -15,7 +15,7 @@
     </div>
   </div>
   <p>To confirm you agree to sign this text message using your selected certificate, please confirm by entering the master password:</p>
-  <input type="password">
+  <input id="certPassword" type="password">
   <button onclick="doCancel()">Cancel</button><button onclick="doOK()">OK</button>
 </form>
 <script src="certChooser.js" type="application/javascript"></script>

--- a/data/certChooser.js
+++ b/data/certChooser.js
@@ -44,6 +44,7 @@ displayCertDetails();
 
 function doOK() {
   data.cancelled = false;
+  data.certPassword = document.getElementById("certPassword").value;
   window.close();
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,6 +50,80 @@ const SEC_PKCS7EncoderOutputCallback = ctypes.FunctionType(ctypes.default_abi,
                                                             ctypes.char.ptr,
                                                             ctypes.int]);
 
+const PK11SlotInfo = ctypes.voidptr_t;
+// These structure definitions are needed,
+// because there is no function in NSS to get slot from certificate.
+const SECAlgorithmID = ctypes.StructType("SECAlgorithmID", [
+  {"algorithm": SECItem},
+  {"parameters": SECItem}
+]);
+const CERTSignedData = ctypes.StructType("CERTSignedData", [
+  {"data": SECItem},
+  {"signatureAlgorithm": SECAlgorithmID},
+  {"signature": SECItem}
+]);
+const CERTName = ctypes.StructType("CERTName", [
+  {"arena": ctypes.voidptr_t},
+  {"CERTRDN": ctypes.voidptr_t.ptr}
+]);
+const CERTValidity = ctypes.StructType("CERTValidity", [
+  {"arena": ctypes.voidptr_t},
+  {"notBefore": SECItem},
+  {"notAfter": SECItem},
+]);
+const CERTSubjectPublicKeyInfo = ctypes.StructType("CERTSubjectPublicKeyInfo", [
+  {"arena": ctypes.voidptr_t},
+  {"algorithm": SECAlgorithmID},
+  {"subjectPublicKey": SECItem}
+]);
+const CERTCertificateStr = ctypes.StructType("CERTCertificateStr", [
+    {"arena": ctypes.voidptr_t},
+    {"subjectName": ctypes.char.ptr},
+    {"issuerName": ctypes.char.ptr},
+    {"signatureWrap": CERTSignedData},
+    {"derCert": SECItem},
+    {"derIssuer": SECItem},
+    {"derSubject": SECItem},
+    {"derPublicKey": SECItem},
+    {"certKey": SECItem},
+    {"version": SECItem},
+    {"serialNumber": SECItem},
+    {"signature": SECAlgorithmID},
+    {"issuer": CERTName},
+    {"validity": CERTValidity},
+    {"subject": CERTName},
+    {"subjectPublicKeyInfo": CERTSubjectPublicKeyInfo},
+    {"issuerID": SECItem},
+    {"subjectID": SECItem},
+    {"extensions": ctypes.voidptr_t.ptr},
+    {"emailAddr": ctypes.char.ptr},
+    {"dbhandle": ctypes.voidptr_t},
+    {"subjectKeyID": SECItem},
+    {"keyIDGenerated": ctypes.int},
+    {"keyUsage": ctypes.unsigned_int},
+    {"rawKeyUsage": ctypes.unsigned_int},
+    {"keyUsagePresent": ctypes.int},
+    {"nsCertType": ctypes.uint32_t},
+    {"keepSession": ctypes.int},
+    {"timeOK": ctypes.int},
+    {"domainOK": ctypes.voidptr_t},
+    {"isperm": ctypes.int},
+    {"istemp": ctypes.int},
+    {"nickname": ctypes.char.ptr},
+    {"dbnickname": ctypes.char.ptr},
+    {"nssCertificate": ctypes.voidptr_t},
+    {"trust": ctypes.voidptr_t},
+    {"referenceCount": ctypes.int},
+    {"subjectList": ctypes.voidptr_t},
+    {"authKeyID": ctypes.voidptr_t},
+    {"isRoot": ctypes.int},
+    {"apointer": ctypes.voidptr_t},
+    {"series": ctypes.int},
+    {"slot": PK11SlotInfo},
+    {"pkcs11ID": ctypes.unsigned_long},
+    {"ownSlot": ctypes.int}
+]);
+
 let nss3 = null;
 let smime3 = null;
 let nspr4 = null;
@@ -64,6 +138,7 @@ let SEC_PKCS7Encode = null;
 let SEC_PKCS7DestroyContentInfo = null;
 let PR_GetError = null;
 let PR_ErrorToString = null;
+let PK11_CheckUserPassword = null;
 
 function platformIsWindows() {
   return runtime.OS == "WINNT";
@@ -163,6 +238,10 @@ function loadLibraries() {
                                      [ctypes.char.ptr,
                                       ctypes.int,
                                       ctypes.voidptr_t]);
+  PK11_CheckUserPassword = declareFunction("PK11_CheckUserPassword", nss3,
+                                     [SECStatus,
+                                      PK11SlotInfo,
+                                      ctypes.char.ptr]);
 }
 
 function unloadLibraries() {
@@ -233,6 +312,7 @@ function selectCert(userCerts, text) {
   sandboxDeclarations += "var certs = {};\n";
   sandboxDeclarations += "var cancelled;\n";
   sandboxDeclarations += "var selectedCert;\n";
+  sandboxDeclarations += "var certPassword;\n";
   sandboxDeclarations += "function Cert() {};\n";
   let sandbox = Cu.Sandbox(data.url("certChooser.html"));
   Cu.evalInSandbox(sandboxDeclarations, sandbox);
@@ -259,10 +339,14 @@ function selectCert(userCerts, text) {
                                     "_blank",
                                     "dialog,centerscreen,chrome,modal",
                                     sandbox);
+  let result = {
+    nickname: sandbox.selectedCert,
+    password: sandbox.certPassword
+  };
   if (sandbox.cancelled) {
-    return ERROR_USER_CANCEL;
+    result.nickname = ERROR_USER_CANCEL;
   }
-  return sandbox.selectedCert;
+  return result;
 }
 
 // charPtr is expected to be null-terminated
@@ -301,7 +385,7 @@ function signText(text) {
   }
 
   let certName = selectCert(userCerts, text);
-  if (certName == ERROR_USER_CANCEL) {
+  if (certName.nickname == ERROR_USER_CANCEL) {
     return ERROR_USER_CANCEL;
   }
 
@@ -318,12 +402,21 @@ function signText(text) {
       logPRError();
       return ERROR_INTERNAL;
     }
-    log("using '" + certName + "'");
-    cert = CERT_FindUserCertByUsage(certDB, certName, certUsageEmailSigner,
+    log("using '" + certName.nickname + "'");
+    cert = CERT_FindUserCertByUsage(certDB, certName.nickname, certUsageEmailSigner,
                                     true, null);
     if (cert.isNull()) {
       log("CERT_FindUserCertByUsage failed");
       logPRError();
+      return ERROR_INTERNAL;
+    }
+
+    // Get certificate slot
+    let slot = ctypes.cast(cert, CERTCertificateStr.ptr).contents.slot;
+    // Check provided password if cert slot needs login
+    if(PK11_CheckUserPassword(slot, certName.password) != SECSuccess) {
+      log("Token password verification failed");
+      cleanupSignTextResources(cert, contentInfo, encodedItem);
       return ERROR_INTERNAL;
     }
 


### PR DESCRIPTION
Added  password check to match native implementation. This way password field will have the same function as in original UI.