### PR TITLE
Seccond atempt to implement password check before signature

### DIFF
--- a/data/certChooser.html
+++ b/data/certChooser.html
@@ -15,7 +15,7 @@
     </div>
   </div>
   <p>To confirm you agree to sign this text message using your selected certificate, please confirm by entering the master password:</p>
-  <input type="password">
+  <input id="certPassword" type="password">
   <button onclick="doCancel()">Cancel</button><button onclick="doOK()">OK</button>
 </form>
 <script src="certChooser.js" type="application/javascript"></script>

--- a/data/certChooser.js
+++ b/data/certChooser.js
@@ -44,6 +44,7 @@ displayCertDetails();
 
 function doOK() {
   data.cancelled = false;
+  data.certPassword = document.getElementById("certPassword").value;
   window.close();
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,6 +27,7 @@ function log(x) {
 const ERROR_NO_MATCHING_CERT = "error:noMatchingCert";
 const ERROR_USER_CANCEL = "error:userCancel";
 const ERROR_INTERNAL = "error:internalError";
+const ERROR_AUTHENTICATION_FAILED = "error:authenticationFailed";
 
 const CERTCertDBHandle = ctypes.voidptr_t;
 const CERTCertificate = ctypes.voidptr_t;
@@ -381,7 +382,7 @@ function signText(text) {
       if (PK11_CheckUserPassword(it.contents.slot, certName.password) != SECSuccess) {
         log("PK11_CheckUserPassword failed");
         cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
-        return ERROR_INTERNAL;
+        return ERROR_AUTHENTICATION_FAILED;
       }
       it = it.contents.next;
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,19 @@ const SEC_PKCS7EncoderOutputCallback = ctypes.FunctionType(ctypes.default_abi,
                                                            [ctypes.voidptr_t,
                                                             ctypes.char.ptr,
                                                             ctypes.int]);
+const PK11SlotInfo = ctypes.voidptr_t;
+let PK11SlotListElement = ctypes.StructType("PK11SlotListElement");
+PK11SlotListElement.define([
+  {"next": PK11SlotListElement.ptr},
+  {"prev": PK11SlotListElement.ptr},
+  {"slot": PK11SlotInfo},
+  {"refCount": ctypes.int}
+]);
+const PK11SlotList = ctypes.StructType("PK11SlotList", [
+  {"head": PK11SlotListElement.ptr},
+  {"tail": PK11SlotListElement.ptr},
+  {"lock": ctypes.voidptr_t}
+]);
 
 let nss3 = null;
 let smime3 = null;
@@ -64,6 +77,9 @@ let SEC_PKCS7Encode = null;
 let SEC_PKCS7DestroyContentInfo = null;
 let PR_GetError = null;
 let PR_ErrorToString = null;
+let PK11_GetAllSlotsForCert = null;
+let PK11_FreeSlotList = null;
+let PK11_CheckUserPassword = null;
 
 function platformIsWindows() {
   return runtime.OS == "WINNT";
@@ -163,6 +179,17 @@ function loadLibraries() {
                                      [ctypes.char.ptr,
                                       ctypes.int,
                                       ctypes.voidptr_t]);
+  PK11_GetAllSlotsForCert = declareFunction("PK11_GetAllSlotsForCert", nss3,
+                                            [PK11SlotList.ptr,
+                                             CERTCertificate,
+                                             ctypes.voidptr_t]);
+  PK11_FreeSlotList = declareFunction("PK11_FreeSlotList", nss3,
+                                      [ctypes.void_t,
+                                       PK11SlotList.ptr]);
+  PK11_CheckUserPassword = declareFunction("PK11_CheckUserPassword", nss3,
+                                           [SECStatus,
+                                            PK11SlotInfo,
+                                            ctypes.char.ptr]);
 }
 
 function unloadLibraries() {
@@ -194,13 +221,22 @@ function getUserCerts() {
   return userCerts;
 }
 
-function cleanupSignTextResources(cert, contentInfo, encodedItem) {
+function cleanupSignTextResources(cert, contentInfo, encodedItem, slotList) {
   try {
     if (cert && !cert.isNull()) {
       CERT_DestroyCertificate(cert);
     }
   } catch (error) {
     log("CERT_DestroyCertificate failed");
+    logPRError();
+  }
+
+  try {
+    if (slotList && !slotList.isNull()) {
+      PK11_FreeSlotList(slotList);
+    }
+  } catch (error) {
+    log("PK11_FreeSlotList failed");
     logPRError();
   }
 
@@ -233,6 +269,7 @@ function selectCert(userCerts, text) {
   sandboxDeclarations += "var certs = {};\n";
   sandboxDeclarations += "var cancelled;\n";
   sandboxDeclarations += "var selectedCert;\n";
+  sandboxDeclarations += "var certPassword;\n";
   sandboxDeclarations += "function Cert() {};\n";
   let sandbox = Cu.Sandbox(data.url("certChooser.html"));
   Cu.evalInSandbox(sandboxDeclarations, sandbox);
@@ -259,10 +296,15 @@ function selectCert(userCerts, text) {
                                     "_blank",
                                     "dialog,centerscreen,chrome,modal",
                                     sandbox);
+  let result = {
+    error: null,
+    nickname: sandbox.selectedCert,
+    password: sandbox.certPassword
+  };
   if (sandbox.cancelled) {
-    return ERROR_USER_CANCEL;
+    result.error = ERROR_USER_CANCEL;
   }
-  return sandbox.selectedCert;
+  return result;
 }
 
 // charPtr is expected to be null-terminated
@@ -301,8 +343,8 @@ function signText(text) {
   }
 
   let certName = selectCert(userCerts, text);
-  if (certName == ERROR_USER_CANCEL) {
-    return ERROR_USER_CANCEL;
+  if (certName.error != null) {
+    return certName.error;
   }
 
   // These are the resources that, if non-null, must be cleaned-up on all code
@@ -310,6 +352,7 @@ function signText(text) {
   let cert = null;
   let contentInfo = null;
   let encodedItem = null;
+  let slotList = null;
 
   try {
     let certDB = CERT_GetDefaultCertDB();
@@ -318,13 +361,29 @@ function signText(text) {
       logPRError();
       return ERROR_INTERNAL;
     }
-    log("using '" + certName + "'");
-    cert = CERT_FindUserCertByUsage(certDB, certName, certUsageEmailSigner,
+    log("using '" + certName.nickname + "'");
+    cert = CERT_FindUserCertByUsage(certDB, certName.nickname, certUsageEmailSigner,
                                     true, null);
     if (cert.isNull()) {
       log("CERT_FindUserCertByUsage failed");
       logPRError();
       return ERROR_INTERNAL;
+    }
+
+    slotList = PK11_GetAllSlotsForCert(cert, null);
+    if (!slotList || !slotList.isNull()) {
+      log("PK11_GetAllSlotsForCert failed");
+      cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
+      return ERROR_INTERNAL;
+    }
+    let it = slotList.contents.head;
+    while (it && !it.isNull()) {
+      if (PK11_CheckUserPassword(it.contents.slot, certName.password) != SECSuccess) {
+        log("PK11_CheckUserPassword failed");
+        cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
+        return ERROR_INTERNAL;
+      }
+      it = it.contents.next;
     }
 
     let digestBytes = hash(text);
@@ -343,7 +402,7 @@ function signText(text) {
     if (contentInfo.isNull()) {
       log("SEC_PKCS7CreateSignedData failed");
       logPRError();
-      cleanupSignTextResources(cert, contentInfo, encodedItem);
+      cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
       return ERROR_INTERNAL;
     }
 
@@ -351,7 +410,7 @@ function signText(text) {
     if (status != SECSuccess) {
       log("SEC_PKCS7IncludeCertChain failed");
       logPRError();
-      cleanupSignTextResources(cert, contentInfo, encodedItem);
+      cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
       return ERROR_INTERNAL;
     }
 
@@ -359,7 +418,7 @@ function signText(text) {
     if (status != SECSuccess) {
       log("SEC_PKCS7AddSigningTime failed");
       logPRError();
-      cleanupSignTextResources(cert, contentInfo, encodedItem);
+      cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
       return ERROR_INTERNAL;
     }
 
@@ -379,15 +438,15 @@ function signText(text) {
     if (status != SECSuccess) {
       log("SEC_PKCS7Encode failed");
       logPRError();
-      cleanupSignTextResources(cert, contentInfo, encodedItem);
+      cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
       return ERROR_INTERNAL;
     }
-    cleanupSignTextResources(cert, contentInfo, encodedItem);
+    cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
     let result = base64.encode(output).replace(/.{64}/g, "$&\n");
     return result;
   } catch (error) {
     log("signText failed: " + error);
-    cleanupSignTextResources(cert, contentInfo, encodedItem);
+    cleanupSignTextResources(cert, contentInfo, encodedItem, slotList);
   }
 
   return ERROR_INTERNAL;


### PR DESCRIPTION
I have reimplemented password check to use `PK11_GetAllSlotsForCert` instead full `CERTCertificateStr` structure.
Also I have added new return value for signText (`error:authenticationFailed`). This is different from native implementation, but I think is more correct behavior. Native function just shows certificate select dialog again if password verification fails, without informing user what's wrong. If certificate is on smart card this makes it easy for user to block card PIN (Caps Lock is on, user enters PIN for different card, etc.). Returning `error:internalError` also is not really informative for the script author so in my opinion it is bad too. Still if you prefer I will change it to work as native version or to return `error:internalError` on authentication error.